### PR TITLE
Fix incorrect branch locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,31 @@ Minimal, complete code-coverage tool for [babel] 6+.
 ![version](http://img.shields.io/npm/v/babel-plugin-transform-adana.svg?style=flat)
 ![downloads](http://img.shields.io/npm/dm/babel-plugin-transform-adana.svg?style=flat)
 
-Has all the features of [istanbul] including line, function and branch coverage, but works as a [babel] plugin instead of relying on `esparse` and `escodegen`. Works great with [west], [mocha], [jasmine] and probably more.
+Has all the features (and more) of [istanbul] including line, function and branch coverage, but works as a [babel] plugin instead of relying on `esparse` and `escodegen`. Works great with [west], [mocha], [jasmine] and probably more.
 
 Features:
 
  * First-class babel support,
  * Per-line/function/branch coverage,
+ * Tagged instrumentation,
  * Smart branch detection.
 
 TODO:
- * Tagged instrumentation,
+ * User-defined tags,
  * More test cases,
  * Split out bins/reporters into other modules.
+
+## FAQ
+
+ * Why is a line marked not covered when it clearly is? - The `line` algorithm is conservative; if you have any part of a line with 0 hits, then that whole line is frozen at 0.
+ * Why is `let i;`, `function foo() {}`, etc. not marked at all? – Some things are not executable code per se (i.e. declarations). They do nothing to effect program state and are therefore not instrumented.
 
 ## Usage
 
 Install `adana`:
 
 ```sh
-npm install --save-dev babel-plugin-transform-adana
+npm install --save-dev babel-plugin-transform-adana adana-cli
 ```
 
 Setup [babel] to use it:
@@ -35,9 +41,11 @@ Setup [babel] to use it:
 {
 	"env": {
 		"test": {
-			"plugins": [
-				"transform-adana"
-			]
+			"plugins": [[
+				"transform-adana", {
+          "test": "src/**/*.js"
+        }
+			]]
 		}
 	}
 }
@@ -53,14 +61,6 @@ NODE_ENV="test" mocha \
 	--compilers js:babel-core/register \
 	test/*.spec.js
 ```
-
-Run some checks:
-
-```sh
-adana-check --statements 100 --branches 100 --functions 100
-```
-
-
 
 ### Tags
 
@@ -146,6 +146,14 @@ On HMR:
 - clear coverage counters for reloaded modules
 - run reloaded code
 - replace coverage counters for reloaded modules
+
+### Other Notes
+
+```js
+// TODO: Allow "merging" of same-hash coverage where the counters are
+// incremented. This could be for someone who has to run a program
+// several times for the same files to cover everything.
+```
 
 
 [babel]: http://babeljs.io

--- a/dump.js
+++ b/dump.js
@@ -1,3 +1,8 @@
-/* global module require */
+/* global require process __coverage__ */
+/* eslint no-var: 0 */
 // Fucking babel. https://github.com/babel/babel/issues/2212
-module.exports = require('./dist/dump').default;
+// Dump that data to disk after tests have finished.
+var dump = require('./dist/dump').default;
+process.on('exit', function() {
+  dump({ coverage: __coverage__, path: 'coverage' });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-syntax-object-rest-spread": "^6.0.2",
     "babel-plugin-transform-object-rest-spread": "^6.0.2",
     "babel-preset-es2015": "^6.0.11",
+    "babylon": "^6.3.26",
     "chai": "^3.4.0",
     "eslint": "^1.8.0",
     "eslint-config-metalab": "^0.3.0",

--- a/share/prelude.js
+++ b/share/prelude.js
@@ -12,6 +12,8 @@ const VARIABLE = (exports => {
 
   exports.__coverage__ = exports.__coverage__ || { };
   exports.__coverage__[FILE] = {
+    hash: HASH,
+    tags: TAGS,
     path: FILE,
     counters: counters,
     locations: LOCATIONS,

--- a/src/dump.js
+++ b/src/dump.js
@@ -1,21 +1,20 @@
-/* global process __coverage__ */
+/* global  */
 
 import { writeFileSync } from 'fs';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import mkdirp from 'mkdirp';
 import lcov from './lcov';
 
-const file = 'coverage/lcov.info';
-const file2 = 'coverage/coverage.json';
+export default function dump({ coverage, path }) {
+  const file = join(path, 'lcov.info');
+  const file2 = join(path, 'coverage.json');
 
-// Dump that data to disk after tests have finished.
-process.on('exit', () => {
-  if (typeof __coverage__ !== 'undefined') {
+  if (typeof coverage !== 'undefined') {
     mkdirp.sync(dirname(file));
-    writeFileSync(file, lcov(__coverage__));
+    writeFileSync(file, lcov(coverage));
   }
-  if (typeof __coverage__ !== 'undefined') {
+  if (typeof coverage !== 'undefined') {
     mkdirp.sync(dirname(file2));
-    writeFileSync(file2, JSON.stringify(__coverage__, null, '  '));
+    writeFileSync(file2, JSON.stringify(coverage, null, '  '));
   }
-});
+}

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -12,8 +12,11 @@ const render = template(readFileSync(
 
 export default function prelude(state) {
   const coverage = meta(state);
-  const name = state.file.opts.filenameRelative || state.file.opts.filename;
+  //  ||
+  const name = state.file.opts.filenameRelative;
   return render({
+    HASH: astify(coverage.hash),
+    TAGS: astify(coverage.tags),
     VARIABLE: coverage.variable,
     FILE: astify(name),
     LOCATIONS: astify(coverage.entries),

--- a/test/fixtures/class-export.fixture.js
+++ b/test/fixtures/class-export.fixture.js
@@ -1,0 +1,7 @@
+
+export class NamedExport {
+
+}
+
+let i = 0;
+++i;

--- a/test/fixtures/logic.fixture.js
+++ b/test/fixtures/logic.fixture.js
@@ -1,0 +1,7 @@
+let y = true;
+const a = !y;
+const b = y;
+const c = y;
+const d = y;
+
+y = !a || (b && c) || d;

--- a/test/fixtures/ternary.fixture.js
+++ b/test/fixtures/ternary.fixture.js
@@ -1,0 +1,6 @@
+
+function foo(i) {
+  return i > 5 ? 3 : 7;
+}
+
+foo(5);

--- a/test/spec/dump.spec.js
+++ b/test/spec/dump.spec.js
@@ -1,0 +1,9 @@
+/* eslint import/no-unresolved: 0 */
+/* eslint import/named: 0 */
+import dump from '../../dist/dump';
+
+describe('dump', () => {
+  it('should output the coverage data', () => {
+    dump({ coverage: { }, path: '/tmp' });
+  });
+});


### PR DESCRIPTION
- Fix tenary statements - One tenary location wasn't being set properly at all, others didn't have quite the right location property.
- Be stricter on generic statements - Only instrument specifically whitelisted statements using the generic instrumenter.
- Fix VM error - The `exports` object was also added to sandbox globals since some babel transforms need this.
- Catch VM errors - By default now all spec VM errors count as test errors, unless you explicitly expect one.
- Change `binaryExpression` to `logicalExpression` - This is now required for some recent version of `babel@6`.
- Include tag metadata in coverage object - Provides more generic `anaylze`.
- Add more tests - Includes arrow functions and logic statements.
- Be more conservative for line run counts - Use the minimum instead of maximum. This still has issues that need sorting out, but at least it's clear now where things are not being run as much.
- Add file hash - Identical hashes can have their coverage data merged if desired.
- More documentation - Not perfect, but better.

There are still hacks in here, but this is a leg up.
