### PR TITLE
Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 sudo: false
 language: node_js
 node_js:
-- 4.1.1
-- '0.12'
+  - 4
+  - 0.12
 before_install:
-- npm update -g npm
+  - npm update -g npm
 after_success:
-- npm install coveralls
-- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - npm install coveralls
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 deploy:
   provider: npm
   email: izaak.schroeder@gmail.com

--- a/README.md
+++ b/README.md
@@ -158,26 +158,7 @@ import { writeFileSync } from 'fs';
 process.on('exit', () => {
   writeFileSync('coverage/coverage.json', JSON.stringify(__coverage__));
 });
-
 ```
-
-### HMR Spec Coverage
-
-foo.spec.js -> foo.js: overwrite coverage info only for foo.js
-
-On HMR:
-- clear coverage counters for reloaded modules
-- run reloaded code
-- replace coverage counters for reloaded modules
-
-### Other Notes
-
-```js
-// TODO: Allow "merging" of same-hash coverage where the counters are
-// incremented. This could be for someone who has to run a program
-// several times for the same files to cover everything.
-```
-
 
 [babel]: http://babeljs.io
 [istanbul]: https://github.com/gotwarlost/istanbul

--- a/README.md
+++ b/README.md
@@ -15,75 +15,88 @@ Features:
  * First-class babel support,
  * Per-line/function/branch coverage,
  * Tagged instrumentation,
+ * User-defined tags,
  * Smart branch detection.
 
-TODO:
- * User-defined tags,
- * More test cases,
- * Split out bins/reporters into other modules.
+## Usage
+
+Install `babel-plugin-transform-adana`:
+
+```sh
+npm install --save-dev babel-plugin-transform-adana
+```
+
+Setup your `.babelrc` to use it:
+
+```json
+{
+  "env": {
+    "test": {
+      "plugins": [[
+        "transform-adana", {
+          "test": "src/**/*.js"
+        }
+      ]]
+    }
+  }
+}
+```
+
+**IMPORTANT**: This plugin works best when it runs as the _first_ plugin in the babel transform list, since its purpose is to instrument your _original code_, not whatever other transformations happen to get made.
+
+```sh
+NODE_ENV="test" mocha \
+  -r babel-plugin-transform-adana/dump \
+  --compilers js:babel-core/register \
+  test/*.spec.js
+```
+
+**NOTE**: This plugin is only responsible for _instrumenting_ your code, not verifying the coverage information or reporting. You can install something like `adana-cli` to get something like `instanbul check-coverage`. See the [adana-cli] repository for more information.
+
+## Tags
+
+There is no `ignore` flag, but you can tag functions, branches or statements which can be used to determine relevant coverage information. This allows you to ask things like "Have I covered all the code that pertains to authentication in the file?" and "Has this run in IE covered all the IE-specific cases?". Existing `ignore` comments simply tag a function with the `ignore` tag.
+
+ * Add a tag with `+tag`, remove a tag with `-tag`.
+ * Tags above a function declaration apply to all code in that function.
+ * Tags above a class declaration apply to all code in that class.
+ * Tags before the first statement of a branch apply to the branch and its code.
+ * Tags on a line apply to everything on that line.
+
+```javascript
+
+/* adana: +ie +firefox -chrome */
+function foo(i) {
+  ++i; // +chrome
+  console.log('foo', i); // adana: +test
+  return i;
+}
+
+
+if (foo(1)) {
+  /* adana: +chrome */
+  console.log('bar');
+}
+```
 
 ## FAQ
 
  * Why is a line marked not covered when it clearly is? - The `line` algorithm is conservative; if you have any part of a line with 0 hits, then that whole line is frozen at 0.
  * Why is `let i;`, `function foo() {}`, etc. not marked at all? – Some things are not executable code per se (i.e. declarations). They do nothing to effect program state and are therefore not instrumented.
 
-## Usage
+## Configuration
 
-Install `adana`:
+There are a couple of configuration options available to control how your program is instrumented. They can be set via the standard mechanism babel employs for configuring transforms.
 
-```sh
-npm install --save-dev babel-plugin-transform-adana adana-cli
-```
-
-Setup [babel] to use it:
-
-```json
+```js
 {
-	"env": {
-		"test": {
-			"plugins": [[
-				"transform-adana", {
-          "test": "src/**/*.js"
-        }
-			]]
-		}
-	}
+  // Pattern to match to determine if the file should be covered. The pattern
+  // is a minimatch compatible string.
+  test: 'src/**/*.js'
 }
 ```
 
-**IMPORTANT**: This plugin works best when it runs as the _first_ plugin in the babel transform list, since its purpose is to instrument your _original code_, not whatever other transformations happen to get made.
-
-Extract the coverage data from node:
-
-```sh
-NODE_ENV="test" mocha \
-	-r babel-plugin-transform-adana/dump \
-	--compilers js:babel-core/register \
-	test/*.spec.js
-```
-
-### Tags
-
-There is no `ignore` flag, but you can tag functions, branches or statements to which can be used to determine relevant coverage information. This allows you to categorize blocks of code and ask things like "Have I covered all the code that pertains to authentication in the file?". Existing `ignore` comments simply tag a function with the `ignore` tag.
-
- * Tags above a block (if/function/etc.) to apply to all code in that block.
- * Tags above or on a line apply to all statements in that line.
-
-```javascript
-
-
-/* adana: +ie +firefox -chrome */
-function foo() {
-	console.log('foo'); // adana: +test
-}
-
-/* adana: +chrome */
-if () {
-
-}
-```
-
-### API
+## API
 
 `adana` is simply a [babel] transformer that injects markers to determine if specific parts of the code have been run. To inject these markers simply add `transform-adana` as a plugin and use [babel] normally:
 
@@ -91,7 +104,7 @@ if () {
 import { transform } from 'babel-core';
 
 const result = transform('some code', {
-	plugins: [ 'transform-adana' ]
+  plugins: [ 'transform-adana' ]
 });
 
 // Access result.code, result.map and result.metadata.coverage
@@ -111,19 +124,29 @@ The `__coverage__` object has the following shape:
 
 ```javascript
 {
-	// Array of counters; the index in this list maps to the same index in the
-	// locations array.
-	counters: [ 0, 0, ... ],
-	// Detailed information about every location that's been instrumented.
-	locations: [{
-		loc: { start: { line: 0, column 0 }, end: { line: 0, column: 0 } },
-		type: 'function|statement|branch',
-		name: 'foo',
-		group: 'bar',
-		tags: [ 'tagA', 'tagB' ]
-	}, {
-		...
-	}, ...]
+  // Hash of the file.
+  hash: '2892834823482374234234235',
+  // Path to the file being instrumented.
+  path: 'some/file.js',
+  // Map between tags and entries in locations.
+  tags: {
+    tagA: [ 1, 2 ],
+    tagB: [ 0, 2, 4 ],
+    ...
+  }
+  // Array of counters; the index in this list maps to the same index in the
+  // locations array.
+  counters: [ 0, 0, ... ],
+  // Detailed information about every location that's been instrumented.
+  locations: [{
+    id: 0,
+    loc: { start: { line: 0, column 0 }, end: { line: 0, column: 0 } },
+    name: 'foo',
+    group: 'bar',
+    tags: [ 'tagA', 'tagB' ]
+  }, {
+    ...
+  }, ...]
 }
 ```
 
@@ -133,7 +156,7 @@ import { writeFileSync } from 'fs';
 
 // Dump that data to disk after tests have finished.
 process.on('exit', () => {
-	writeFileSync('coverage/coverage.json', JSON.stringify(__coverage__));
+  writeFileSync('coverage/coverage.json', JSON.stringify(__coverage__));
 });
 
 ```
@@ -162,3 +185,4 @@ On HMR:
 [jasmine]: http://jasmine.github.io/
 [west]: https://www.github.com/izaakschroeder/west
 [lcov]: http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php
+[adana-cli]: https://www.github.com/izaakschroeder/adana-cli

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "babel-literal-to-ast": "^0.1.2",
     "babel-template": "^6.0.14",
+    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1"
   }
 }

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -42,13 +42,8 @@ function lines(statements) {
 }
 
 export default function analyze(coverage) {
-  const statements = type('statement', coverage);
-  const branches = type('branch', coverage);
-  const functions = type('function', coverage);
-  return {
-    statements,
-    lines: lines(type('line', coverage)),
-    branches,
-    functions,
-  };
+  const results = { };
+  Object.keys(coverage.tags).forEach(tag => results[tag] = type(tag, coverage));
+  results.line = lines(results.line);
+  return results;
 }

--- a/src/lcov.js
+++ b/src/lcov.js
@@ -4,7 +4,11 @@ import analyze from './analyze';
 export default function lcov(coverage) {
   const files = Object.keys(coverage);
   return files.map(file => {
-    const { functions, lines, branches } = analyze(coverage[file]);
+    const {
+      function: functions = [],
+      line: lines = [],
+      branch: branches = [],
+    } = analyze(coverage[file]);
     return `
 TN:
 SF: ${file}

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,14 +1,72 @@
+import meta from './meta';
 
-const COMMENT_PATTERN = /^\s*@?(adana|coverage|test|istanbul):? (.*)/;
-// const TAG_PATTERN = /[+-]\s?(\w+)/g;
+const COMMENT_PATTERN = /^\s*@?(adana|coverage|test|istanbul):?\s*(.*)\s*/;
 
-export default function tags(path) {
-  return path.getAncestry()
-    .map(n => n.node.leadingComments || [])
-    .reduce((entries, comment) => {
-      // comment.type === 'CommentLine'
-      // comment.type === 'CommentBlock'
-      const result = COMMENT_PATTERN.exec(comment.value);
-      return result ? [ ...entries, result[2] ] : entries;
-    }, []);
+function within(a, b) {
+  return a.start.line >= b.start.line &&
+    a.start.column >= b.start.column &&
+    a.end.line <= b.end.line &&
+    a.end.column <= b.end.column;
+}
+
+export function applyRules(state) {
+  const coverage = meta(state);
+  coverage.entries.forEach(entry => {
+    const result = { };
+    const output = [ ];
+    entry.tags.forEach(tag => result[tag] = true);
+    coverage.rules.forEach(rule => {
+      if (within(rule.loc, entry.loc)) {
+        result[rule.tag] = rule.value;
+      }
+    });
+    Object.keys(result).forEach(tag => {
+      const value = result[tag];
+      if (value) {
+        output.push(tag);
+        if (!coverage.tags[tag]) {
+          coverage.tags[tag] = [];
+        }
+        coverage.tags[tag].push(entry.id);
+      }
+    });
+    entry.tags = output;
+  });
+}
+
+export function extract(comment) {
+  const output = { };
+  const result = COMMENT_PATTERN.exec(comment);
+  if (result) {
+    const entries = result[2].split(/\s+/);
+    entries.forEach(entry => {
+      switch (entry.charAt(0)) {
+      case '+':
+        output[entry.substr(1)] = true;
+        break;
+      case '-':
+        output[entry.substr(1)] = false;
+        break;
+      default:
+        break;
+      }
+    });
+  }
+  return output;
+}
+
+export function addRules(state, loc, comments) {
+  if (comments) {
+    const coverage = meta(state);
+    comments.forEach(comment => {
+      const values = extract(comment.value);
+      Object.keys(values).forEach(tag => {
+        coverage.rules.push({
+          tag,
+          value: values[tag],
+          loc,
+        });
+      });
+    });
+  }
 }

--- a/src/tags.js
+++ b/src/tags.js
@@ -6,6 +6,8 @@ export default function tags(path) {
   return path.getAncestry()
     .map(n => n.node.leadingComments || [])
     .reduce((entries, comment) => {
+      // comment.type === 'CommentLine'
+      // comment.type === 'CommentBlock'
       const result = COMMENT_PATTERN.exec(comment.value);
       return result ? [ ...entries, result[2] ] : entries;
     }, []);

--- a/test/fixtures/tag-block.fixture.js
+++ b/test/fixtures/tag-block.fixture.js
@@ -1,0 +1,6 @@
+let i = 0;
+/* adana: +foo */
+++i;
+++i;
+/* adana: -foo */
+--i;

--- a/test/fixtures/tag-branch.fixture.js
+++ b/test/fixtures/tag-branch.fixture.js
@@ -1,0 +1,33 @@
+let i = 1;
+
+if (i > 2) /* adana: +foo */ {
+  i = i + 5;
+} else if (i > 1) {
+  /* adana: +bar */
+  i = i + 1;
+} else {
+  /* adana: +baz */
+  i = i - 1;
+}
+
+switch (i) {
+case 0 /* adana: +foo */:
+  i = 3;
+  break;
+case 1:
+  /* adana: +bar */
+  i = 5;
+  break;
+case 2 /* adana: +baz */:
+  i = 7;
+  break;
+default:
+  /* adana: +qux */
+  i = 0;
+  break;
+}
+
+let j = i > 3 ?
+  /* adana: +foo */ 0 : /* adana: +bar */ 1;
+
+++j;

--- a/test/fixtures/tag-line.fixture.js
+++ b/test/fixtures/tag-line.fixture.js
@@ -1,0 +1,5 @@
+
+let i = 0;
+
+++i; // adana: +foo
+++i;

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -1,4 +1,3 @@
-
 import { expect } from 'chai';
 import path from 'path';
 import vm from 'vm';
@@ -37,7 +36,6 @@ describe('Instrumenter', () => {
       let error = null;
       sandbox.global = { };
       sandbox.exports = { };
-      // console.log(data.code);
       try {
         vm.runInContext(data.code, sandbox);
       } catch (err) {
@@ -50,6 +48,7 @@ describe('Instrumenter', () => {
         ...(!sandbox.global.__coverage__ ?
           { } : analyze(sandbox.global.__coverage__[file])
         ),
+        coverage: sandbox.global.__coverage__[file],
         code: data.code,
         error,
       };
@@ -238,6 +237,38 @@ describe('Instrumenter', () => {
   describe('classes', () => {
     it('should handle exported classes', () => {
       return run('class-export').then(({ statement }) => {
+        expect(statement).to.have.length(2);
+      });
+    });
+  });
+
+  describe('tags', () => {
+    it.skip('should handle line tags', () => {
+      return run('tag-line').then(({ statement }) => {
+        expect(statement).to.have.length(2);
+      });
+    });
+    it('should handle branch tags', () => {
+      return run('tag-branch').then(results => {
+        expect(results).to.have.property('foo').to.have.length(4);
+        expect(results.foo[0]).to.have.property('count', 0);
+        expect(results.foo[1]).to.have.property('count', 1);
+        expect(results.foo[2]).to.have.property('count', 1);
+        expect(results.foo[3]).to.have.property('count', 0);
+        expect(results).to.have.property('bar').to.have.length(4);
+        expect(results.bar[0]).to.have.property('count', 0);
+        expect(results.bar[1]).to.have.property('count', 0);
+        expect(results.bar[2]).to.have.property('count', 1);
+        expect(results.bar[3]).to.have.property('count', 1);
+        expect(results).to.have.property('baz').to.have.length(2);
+        expect(results.baz[0]).to.have.property('count', 1);
+        expect(results.baz[1]).to.have.property('count', 0);
+        expect(results).to.have.property('qux').to.have.length(1);
+        expect(results.qux[0]).to.have.property('count', 0);
+      });
+    });
+    it.skip('should handle block tags', () => {
+      return run('tag-block').then(({ statement }) => {
         expect(statement).to.have.length(2);
       });
     });

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -64,10 +64,10 @@ describe('Instrumenter', () => {
 
   describe('statements', () => {
     it('should cover simple statements', () => {
-      return run('statements').then(({ statements }) => {
-        expect(statements).to.have.length(2);
-        expect(statements[0]).to.have.property('count', 1);
-        expect(statements[1]).to.have.property('count', 1);
+      return run('statements').then(({ statement }) => {
+        expect(statement).to.have.length(2);
+        expect(statement[0]).to.have.property('count', 1);
+        expect(statement[1]).to.have.property('count', 1);
       });
     });
   });
@@ -87,12 +87,12 @@ describe('Instrumenter', () => {
       expect(metadata.coverage).to.have.property('entries').to.have.length(0);
     });
     it('should cover do-while loops', () => {
-      return run('do-while').then(({ branches, statements }) => {
-        expect(statements).to.have.length(3);
-        expect(statements[2]).to.have.property('count', 5);
-        expect(branches).to.have.length(2);
-        expect(branches[0]).to.have.property('count', 4);
-        expect(branches[1]).to.have.property('count', 1);
+      return run('do-while').then(({ branch, statement }) => {
+        expect(statement).to.have.length(3);
+        expect(statement[2]).to.have.property('count', 5);
+        expect(branch).to.have.length(2);
+        expect(branch[0]).to.have.property('count', 4);
+        expect(branch[1]).to.have.property('count', 1);
       });
     });
   });
@@ -112,66 +112,64 @@ describe('Instrumenter', () => {
       expect(metadata.coverage).to.have.property('entries').to.have.length(0);
     });
     it('should cover exceptions', () => {
-      return run('try-catch').then(({ branches }) => {
-        expect(branches).to.have.length(2);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 1);
+      return run('try-catch').then(({ branch }) => {
+        expect(branch).to.have.length(2);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 1);
       });
     });
     it('should cover exceptions', () => {
       return run('try-no-catch', { error: true })
-        .then(({ branches, error }) => {
+        .then(({ branch, error }) => {
           expect(error).to.not.be.null;
-          expect(branches).to.have.length(2);
-          expect(branches[0]).to.have.property('count', 0);
-          expect(branches[1]).to.have.property('count', 1);
+          expect(branch).to.have.length(2);
+          expect(branch[0]).to.have.property('count', 0);
+          expect(branch[1]).to.have.property('count', 1);
         });
     });
   });
 
   describe('functions', () => {
     it('should cover functions', () => {
-      return run('function').then(({ branches, functions }) => {
-        expect(branches).to.have.length(0);
-        expect(functions).to.have.length(2);
-        expect(functions[0]).to.have.property('count', 2);
-        expect(functions[1]).to.have.property('count', 0);
+      return run('function').then(result => {
+        expect(result.function).to.have.length(2);
+        expect(result.function[0]).to.have.property('count', 2);
+        expect(result.function[1]).to.have.property('count', 0);
       });
     });
     it('should cover arrow functions', () => {
-      return run('arrow-function').then(({ branches, functions }) => {
-        expect(branches).to.have.length(0);
-        expect(functions).to.have.length(1);
-        expect(functions[0]).to.have.property('count', 1);
+      return run('arrow-function').then(result => {
+        expect(result.function).to.have.length(1);
+        expect(result.function[0]).to.have.property('count', 1);
       });
     });
   });
 
   describe('ternary expressions', () => {
     it('should cover ternary expressions', () => {
-      return run('ternary').then(({ branches }) => {
-        expect(branches).to.have.length(2);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 1);
+      return run('ternary').then(({ branch }) => {
+        expect(branch).to.have.length(2);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 1);
       });
     });
   });
 
   describe('if blocks', () => {
     it('should cover if-else-if blocks', () => {
-      return run('if-else-if').then(({ branches }) => {
-        expect(branches).to.have.length(4);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 0);
-        expect(branches[2]).to.have.property('count', 1);
+      return run('if-else-if').then(({ branch }) => {
+        expect(branch).to.have.length(4);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 0);
+        expect(branch[2]).to.have.property('count', 1);
         // TODO: Ensure all branches map to same group
       });
     });
     it('should cover if-else blocks', () => {
-      return run('if-else').then(({ branches }) => {
-        expect(branches).to.have.length(2);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 1);
+      return run('if-else').then(({ branch }) => {
+        expect(branch).to.have.length(2);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 1);
         // TODO: Ensure all branches map to same group
       });
     });
@@ -179,14 +177,14 @@ describe('Instrumenter', () => {
 
   describe('logic expressions', () => {
     it('should cover logic', () => {
-      return run('logic').then(({ branches }) => {
-        expect(branches).to.have.length(6);
-        expect(branches[0]).to.have.property('count', 1);
-        expect(branches[1]).to.have.property('count', 0);
-        expect(branches[2]).to.have.property('count', 1);
-        expect(branches[3]).to.have.property('count', 0);
-        expect(branches[4]).to.have.property('count', 0);
-        expect(branches[5]).to.have.property('count', 0);
+      return run('logic').then(({ branch }) => {
+        expect(branch).to.have.length(6);
+        expect(branch[0]).to.have.property('count', 1);
+        expect(branch[1]).to.have.property('count', 0);
+        expect(branch[2]).to.have.property('count', 1);
+        expect(branch[3]).to.have.property('count', 0);
+        expect(branch[4]).to.have.property('count', 0);
+        expect(branch[5]).to.have.property('count', 0);
         // TODO: Ensure all branches map to same group
       });
     });
@@ -207,20 +205,20 @@ describe('Instrumenter', () => {
       expect(metadata.coverage).to.have.property('entries').to.have.length(0);
     });
     it('should cover switch statements', () => {
-      return run('switch').then(({ branches }) => {
-        expect(branches).to.have.length(3);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 0);
-        expect(branches[2]).to.have.property('count', 1);
+      return run('switch').then(({ branch }) => {
+        expect(branch).to.have.length(3);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 0);
+        expect(branch[2]).to.have.property('count', 1);
         // TODO: Ensure all branches map to same group
       });
     });
     it('should cover switch statements without `default` rules', () => {
-      return run('switch-no-default').then(({ branches }) => {
-        expect(branches).to.have.length(3);
-        expect(branches[0]).to.have.property('count', 0);
-        expect(branches[1]).to.have.property('count', 0);
-        expect(branches[2]).to.have.property('count', 1);
+      return run('switch-no-default').then(({ branch }) => {
+        expect(branch).to.have.length(3);
+        expect(branch[0]).to.have.property('count', 0);
+        expect(branch[1]).to.have.property('count', 0);
+        expect(branch[2]).to.have.property('count', 1);
         // TODO: Ensure all branches map to same group
       });
     });
@@ -228,10 +226,10 @@ describe('Instrumenter', () => {
 
   describe('while loops', () => {
     it('should cover while loops', () => {
-      return run('while').then(({ branches }) => {
-        expect(branches).to.have.length(2);
-        expect(branches[0]).to.have.property('count', 4);
-        expect(branches[1]).to.have.property('count', 1);
+      return run('while').then(({ branch }) => {
+        expect(branch).to.have.length(2);
+        expect(branch[0]).to.have.property('count', 4);
+        expect(branch[1]).to.have.property('count', 1);
         // TODO: Ensure all branches map to same group
       });
     });
@@ -239,8 +237,8 @@ describe('Instrumenter', () => {
 
   describe('classes', () => {
     it('should handle exported classes', () => {
-      return run('class-export').then(({ statements }) => {
-        expect(statements).to.have.length(2);
+      return run('class-export').then(({ statement }) => {
+        expect(statement).to.have.length(2);
       });
     });
   });

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -11,7 +11,9 @@ import plugin, { key } from '../../dist/instrumenter';
 
 describe('Instrumenter', () => {
   const options = {
-    plugins: [ '../' ],
+    plugins: [ [ '../', {
+      test: '!**test/spec/*.spec.js',
+    } ] ],
     presets: [ ],
     sourceMaps: true,
     ast: false,
@@ -59,6 +61,56 @@ describe('Instrumenter', () => {
     it('should fail with no location', () => {
       expect(() => key({ node: { } })).to.throw(TypeError);
     });
+  });
+
+  it('should ignore non-matching files', () => {
+    const fixture = parse(`let i = 0; ++i;`);
+    const instrumenter = plugin({ types });
+    const metadata = { };
+    traverse(
+      fixture,
+      instrumenter.visitor,
+      null,
+      {
+        file: {
+          code: '',
+          metadata,
+          opts: {
+            filenameRelative: 'foo.css',
+            filename: '/foo/foo.css',
+          },
+        },
+        opts: {
+          test: '**/*.js',
+        },
+      }
+    );
+    expect(metadata).to.not.have.property('coverage');
+  });
+
+  it('should accept matching files', () => {
+    const fixture = parse(`let i = 0; ++i;`);
+    const instrumenter = plugin({ types });
+    const metadata = { };
+    traverse(
+      fixture,
+      instrumenter.visitor,
+      null,
+      {
+        file: {
+          code: '',
+          metadata,
+          opts: {
+            filenameRelative: 'foo.js',
+            filename: '/foo/foo.js',
+          },
+        },
+        opts: {
+          test: '**/*.js',
+        },
+      }
+    );
+    expect(metadata).to.have.property('coverage');
   });
 
   describe('statements', () => {

--- a/test/spec/tags.spec.js
+++ b/test/spec/tags.spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+/* eslint import/no-unresolved: 0 */
+/* eslint import/named: 0 */
+import { extract } from '../../dist/tags';
+
+describe('tags', () => {
+  it('should extract tags from comments properly', () => {
+    const result = extract(' adana: +foo -bar baz');
+    expect(result).to.have.property('foo', true);
+    expect(result).to.have.property('bar', false);
+    expect(result).to.not.have.property('baz');
+  });
+});


### PR DESCRIPTION
Previously there were `statements`, `branches`, etc. in the analysis results; now all that remains is whatever tags are present in the instrumented file. This means if there are no branches then there will be no `branch` entry in the analysis. The names of the tags are singular, so the resulting object has singular keys.

Tags around if statements and switch statements are now available. This means you can tag the result of a specific branch, and therefore effectively "ignore" certain branches.

Some files you do not want instrumented, and so there is now a plugin option called `test` which is a minimatch pattern that must pass for the file to be instrumented. The default is to ignore anything in a test folder. Seems sensible, may change in the future.
