### PR TITLE
Instrument code in separate `traverse` pass.

### DIFF
--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -181,6 +181,19 @@ describe('Instrumenter', () => {
   });
 
   describe('functions', () => {
+    it('should ignore previously instrumented function', () => {
+      const fixture = parse(`function foo() { };`);
+      const instrumenter = plugin({ types });
+      const metadata = { };
+      fixture.program.body[0].__adana = true;
+      traverse(
+        fixture,
+        instrumenter.visitor,
+        null,
+        { file: { code: '', metadata, opts: { filenameRelative: '' } } }
+      );
+      expect(metadata.coverage).to.have.property('entries').to.have.length(0);
+    });
     it('should cover functions', () => {
       return run('function').then(({ tags }) => {
         expect(tags.function).to.have.length(2);


### PR DESCRIPTION
There is a bug (the origin of which I am unsure) whereby using adana as part of a preset results in no plugins being applied. My original thought was it had to do with `path.skip()` but even this seems not to be the case.

Looking at other plugins, everyone else seems to use `.traverse()` with a separate visitor; I emulated this and the problem seems to go away and everything still works. So that's what we're going with.

It appears this alters the instrumentation path somewhat as well, so more tests have been added to check against cases that are now no longer invoked by default. It also appears that `instrument` is now never called with an "invalid" (no location) entry, so the check has been removed. It may turn out that is totally wrong in which case a test will be added that actually manages to trigger it.
