### PR TITLE
Check for `__coverage__` before dumping.

### DIFF
--- a/dump.js
+++ b/dump.js
@@ -4,5 +4,8 @@
 // Dump that data to disk after tests have finished.
 var dump = require('./dist/dump').default;
 process.on('exit', function() {
-  dump({ coverage: __coverage__, path: 'coverage' });
+  dump({
+    coverage: typeof __coverage__ !== 'undefined' ? __coverage__ : { },
+    path: 'coverage',
+  });
 });

--- a/src/dump.js
+++ b/src/dump.js
@@ -3,11 +3,9 @@ import { dirname, join } from 'path';
 import mkdirp from 'mkdirp';
 
 export default function dump({ coverage, path, pretty }) {
-  if (typeof coverage !== 'undefined') {
-    const file2 = join(path, 'coverage.json');
-    const data = pretty ?
-      JSON.stringify(coverage, null, '  ') : JSON.stringify(coverage);
-    mkdirp.sync(dirname(file2));
-    writeFileSync(file2, data);
-  }
+  const file2 = join(path, 'coverage.json');
+  const data = pretty ?
+    JSON.stringify(coverage, null, '  ') : JSON.stringify(coverage);
+  mkdirp.sync(dirname(file2));
+  writeFileSync(file2, data);
 }


### PR DESCRIPTION
Avoid `undefined` errors when no files are instrumented.
