### PR TITLE
Use `babel-core`'s ignore mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Setup your `.babelrc` to use it:
     "test": {
       "plugins": [[
         "transform-adana", {
-          "test": "src/**/*.js"
+          "ignore": "test/**/*"
         }
       ]]
     }
@@ -154,8 +154,14 @@ There are a couple of configuration options available to control how your progra
 ```js
 {
   // Pattern to match to determine if the file should be covered. The pattern
-  // is a minimatch compatible string.
-  test: 'src/**/*.js',
+  // must be matched for coverage to be enabled for the file. Takes precedence
+  // over `ignore`.
+  // See `only` of https://babeljs.io/docs/usage/options/
+  only: 'src/**/*.js',
+  // Pattern to match to determine if the file should NOT be covered. The
+  // pattern must NOT be matched for coverage to be enabled for the file.
+  // See `ignore` of https://babeljs.io/docs/usage/options/
+  ignore: 'test/**/*',
   // Name of the global variable to store all the collected coverage information
   // in.
   global: '__coverage__'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "babel-literal-to-ast": "^0.1.2",
     "babel-template": "^6.0.14",
-    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1"
   }
 }

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import minimatch from 'minimatch';
+import { util } from 'babel-core';
 import prelude from './prelude';
 import meta from './meta';
 import { applyRules, addRules } from './tags';
@@ -8,10 +8,16 @@ export function hash(code) {
   return createHash('sha1').update(code).digest('hex');
 }
 
-export function skip(state) {
-  const pattern = (state.opts && state.opts.test) || '!**/test/**';
-  return state.file.opts.filename &&
-    !minimatch(state.file.opts.filename, pattern);
+export function skip({ opts, file } = { }) {
+  if (file && opts) {
+    const { ignore = [], only } = opts;
+    return util.shouldIgnore(
+      file.opts.filename,
+      util.arrayify(ignore, util.regexify),
+      only ? util.arrayify(only, util.regexify) : null
+    );
+  }
+  return false;
 }
 
 /**

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -12,7 +12,7 @@ import plugin, { key } from '../../dist/instrumenter';
 describe('Instrumenter', () => {
   const options = {
     plugins: [ [ '../', {
-      test: '!**test/spec/*.spec.js',
+      ignore: 'test/spec/*.spec.js',
     } ] ],
     presets: [ ],
     sourceMaps: true,
@@ -63,7 +63,7 @@ describe('Instrumenter', () => {
     });
   });
 
-  it('should ignore non-matching files', () => {
+  it('should ignore non-matching files via `ignore`', () => {
     const fixture = parse(`let i = 0; ++i;`);
     const instrumenter = plugin({ types });
     const metadata = { };
@@ -81,7 +81,32 @@ describe('Instrumenter', () => {
           },
         },
         opts: {
-          test: '**/*.js',
+          ignore: '**/*.css',
+        },
+      }
+    );
+    expect(metadata).to.not.have.property('coverage');
+  });
+
+  it('should ignore non-matching files via `only`', () => {
+    const fixture = parse(`let i = 0; ++i;`);
+    const instrumenter = plugin({ types });
+    const metadata = { };
+    traverse(
+      fixture,
+      instrumenter.visitor,
+      null,
+      {
+        file: {
+          code: '',
+          metadata,
+          opts: {
+            filenameRelative: 'foo.css',
+            filename: '/foo/foo.css',
+          },
+        },
+        opts: {
+          only: '**/*.js',
         },
       }
     );


### PR DESCRIPTION
This makes the plugin configuration more consistent with how babel works normally and should be more familiar to users.

This is a breaking change.
