### PR TITLE
Check for destructuring patterns.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -363,14 +363,15 @@ export default function adana({ types }) {
    * @returns {[type]}       [description]
    */
   function visitObjectProperty(path, state) {
-    if (!path.node.shorthand) {
+    if (!path.node.shorthand && !path.parentPath.isPattern()) {
       const key = path.get('key');
+      const value = path.get('value');
       if (key.isExpression()) {
         instrument(key, state, {
           tags: [ 'line' ],
         });
       }
-      instrument(path.get('value'), state, {
+      instrument(value, state, {
         tags: [ 'line' ],
       });
     }
@@ -385,11 +386,13 @@ export default function adana({ types }) {
    * @returns {[type]}       [description]
    */
   function visitArrayExpression(path, state) {
-    path.get('elements').forEach(element => {
-      instrument(element, state, {
-        tags: [ 'line' ],
+    if (!path.parentPath.isPattern()) {
+      path.get('elements').forEach(element => {
+        instrument(element, state, {
+          tags: [ 'line' ],
+        });
       });
-    });
+    }
   }
 
   /**

--- a/test/fixtures/object-destructured.fixture.js
+++ b/test/fixtures/object-destructured.fixture.js
@@ -1,0 +1,11 @@
+
+function foo({ environment: x }) {
+  return x + 1;
+}
+
+function bar([ a, b ]) {
+  return a + b;
+}
+
+foo({ environment: 5 });
+bar([ 1, 2 ]);

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -298,6 +298,12 @@ describe('Instrumenter', () => {
         expect(line(6, lines)).to.have.property('count', 1);
       });
     });
+
+    it('should handle destructured objects', () => {
+      return run('object-destructured').then(({ lines }) => {
+        expect(line(6, lines)).to.have.property('count', 1);
+      });
+    });
   });
 
   describe('switch blocks', () => {


### PR DESCRIPTION
Marker injection should not be done for destructuring patterns, since they neither make any sense nor do they compile properly.

Previously there was no logic to detect the fact that in:

``` javascript
const x = ({ x: y }) => y;
```

The identifier `y` was not a reference but a declaration. So now destructuring patterns are simply ignored. Test added to verify this behavior for objects and arrays.
