### PR TITLE
Fix invalid conditional group state.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -438,6 +438,7 @@ export default function adana({ types }) {
     // grouping.
     const root = path.findParent(search => {
       return search.node.type === path.node.type &&
+        !ignore(search) &&
         (!search.parentPath || search.parentPath.node.type !== path.node.type);
     }) || path;
 

--- a/test/fixtures/branch-double.fixture.js
+++ b/test/fixtures/branch-double.fixture.js
@@ -1,0 +1,6 @@
+
+const a = false;
+const b = true;
+let x = a || (b ? '/' : null);
+
+x = `${x}hello`;

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -31,6 +31,14 @@ describe('Instrumenter', () => {
     }
   }
 
+  function grouped(...entries) {
+    if (entries.length <= 0) {
+      return;
+    }
+    const base = entries[0].group;
+    entries.forEach(entry => expect(entry.group).to.equal(base));
+  }
+
   function transform(fixture) {
     const file = path.join('.', 'test', 'fixtures', `${fixture}.fixture.js`);
     return (new Promise((resolve, reject) => {
@@ -255,6 +263,14 @@ describe('Instrumenter', () => {
         expect(tags.branch[1]).to.have.property('count', 1);
       });
     });
+
+    it('should cover adjunct ternary expressions', () => {
+      return run('branch-double').then(({ tags }) => {
+        expect(tags.branch).to.have.length(4);
+        grouped(tags.branch[0], tags.branch[1]);
+        grouped(tags.branch[2], tags.branch[3]);
+      });
+    });
   });
 
   describe('if blocks', () => {
@@ -264,7 +280,7 @@ describe('Instrumenter', () => {
         expect(tags.branch[0]).to.have.property('count', 0);
         expect(tags.branch[1]).to.have.property('count', 0);
         expect(tags.branch[2]).to.have.property('count', 1);
-        // TODO: Ensure all branches map to same group
+        grouped(...tags.branch);
       });
     });
     it('should cover if-else blocks', () => {
@@ -272,7 +288,7 @@ describe('Instrumenter', () => {
         expect(tags.branch).to.have.length(2);
         expect(tags.branch[0]).to.have.property('count', 0);
         expect(tags.branch[1]).to.have.property('count', 1);
-        // TODO: Ensure all branches map to same group
+        grouped(...tags.branch);
       });
     });
   });
@@ -287,7 +303,8 @@ describe('Instrumenter', () => {
         expect(tags.branch[3]).to.have.property('count', 0);
         expect(tags.branch[4]).to.have.property('count', 0);
         expect(tags.branch[5]).to.have.property('count', 0);
-        // TODO: Ensure all branches map to same group
+        // TODO: Fix grouping for logic statements.
+        // grouped(...tags.branch);
       });
     });
   });
@@ -326,7 +343,7 @@ describe('Instrumenter', () => {
         expect(tags.branch[0]).to.have.property('count', 0);
         expect(tags.branch[1]).to.have.property('count', 0);
         expect(tags.branch[2]).to.have.property('count', 1);
-        // TODO: Ensure all branches map to same group
+        grouped(...tags.branch);
       });
     });
     it('should cover switch statements without `default` rules', () => {
@@ -335,7 +352,7 @@ describe('Instrumenter', () => {
         expect(tags.branch[0]).to.have.property('count', 0);
         expect(tags.branch[1]).to.have.property('count', 0);
         expect(tags.branch[2]).to.have.property('count', 1);
-        // TODO: Ensure all branches map to same group
+        grouped(...tags.branch);
       });
     });
   });
@@ -346,7 +363,7 @@ describe('Instrumenter', () => {
         expect(tags.branch).to.have.length(2);
         expect(tags.branch[0]).to.have.property('count', 4);
         expect(tags.branch[1]).to.have.property('count', 1);
-        // TODO: Ensure all branches map to same group
+        grouped(...tags.branch);
       });
     });
   });


### PR DESCRIPTION
The majority of branches detect the groups they belong to; that is to say if you have:

``` javascript
if (foo) {

} else if (bar) {

} else {

}
```

The several branches in there all belong to the same logical group. The same effect occurs for logic statements, tenary ifs and so on. The group detection logic, however, did not take into account adana generated nodes and so compound conditionals with adana generated nodes would result in key errors.

This is now fixed and checks have been added to ensure the correct groups are calculated for the majority of cases. Logic statements still need work, simply because of how they are rewritten for instrumentation.
