### PR TITLE
Fix non-computed object keys being instrumented.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -366,7 +366,7 @@ export default function adana({ types }) {
     if (!path.node.shorthand && !path.parentPath.isPattern()) {
       const key = path.get('key');
       const value = path.get('value');
-      if (key.isExpression()) {
+      if (path.node.computed) {
         instrument(key, state, {
           tags: [ 'line' ],
         });

--- a/test/fixtures/object-string-key.fixture.js
+++ b/test/fixtures/object-string-key.fixture.js
@@ -1,0 +1,6 @@
+
+const object = {
+  'foo': 5, /* eslint quote-props: 0 */
+};
+
+++object.foo;

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -321,6 +321,12 @@ describe('Instrumenter', () => {
         expect(line(6, lines)).to.have.property('count', 1);
       });
     });
+
+    it('should handle objects with string keys', () => {
+      return run('object-string-key').then(({ lines }) => {
+        expect(line(6, lines)).to.have.property('count', 1);
+      });
+    });
   });
 
   describe('switch blocks', () => {


### PR DESCRIPTION
The original design was only to instrument computed keys in `[here]: ...`, but the check being used was wrong and caused string literals as keys to fail. `babel` has always been a bit sparse on the internal AST docs. This has been fixed and a new test has been created to verify the fix.

Regression introduced in: https://github.com/adana-coverage/babel-plugin-transform-adana/commit/c5e7a9fba93c0b82da985c3f6aa245545d8344b4. Thanks to @olegskl for reporting.

Resolves https://github.com/adana-coverage/babel-plugin-transform-adana/issues/30.
