### PR TITLE
Classify object methods as functions.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -487,6 +487,7 @@ export default function adana({ types }) {
     // Expressions
     ArrowFunctionExpression: visitFunction,
     FunctionExpression: visitFunction,
+    ObjectMethod: visitFunction,
     LogicalExpression: visitLogicalExpression,
     ConditionalExpression: visitConditional,
     ObjectProperty: visitObjectProperty,

--- a/test/fixtures/function-property.fixture.js
+++ b/test/fixtures/function-property.fixture.js
@@ -1,0 +1,7 @@
+const object = {
+  foo(a, b) {
+    return a + b;
+  },
+};
+
+object.foo(1, 2);

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -253,6 +253,12 @@ describe('Instrumenter', () => {
         expect(tags.function[0]).to.have.property('count', 1);
       });
     });
+    it('should cover object methods', () => {
+      return run('function-property').then(({ lines, tags }) => {
+        expect(tags.function).to.have.length(1);
+        expect(line(3, lines)).to.have.property('count', 1);
+      });
+    });
   });
 
   describe('ternary expressions', () => {


### PR DESCRIPTION
Seems like the sane thing to do. The same treatment should probably be applied to class methods (for `ClassMethod` nodes).

This should fix https://github.com/adana-coverage/babel-plugin-transform-adana/issues/34.
