### PR TITLE
Add support for `try` and `catch` tagging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore .",
     "prepublish": "./node_modules/.bin/babel -s inline -d dist src/",
-    "prespec": "npm run prepublish && ./node_modules/.bin/babel --plugins ./,transform-es2015-modules-commonjs -d dist src/",
+    "prespec": "npm run prepublish && ./node_modules/.bin/babel --plugins `pwd`,transform-es2015-modules-commonjs -d dist src/",
     "spec": "NODE_ENV=test ./node_modules/.bin/_mocha -r adana-dump --slow 200 --compilers js:babel-core/register -R spec test/spec",
     "test": "npm run lint && npm run spec"
   },

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -290,6 +290,8 @@ export default function adana({ types }) {
    */
   function visitTryStatement(path, state) {
     const group = key(path);
+    const body = path.get('block');
+    addRules(state, body.node.loc, body.node.leadingComments);
     path.get('block').pushContainer('body', types.expressionStatement(
       createMarker(state, {
         tags: [ 'branch', 'line' ],
@@ -298,6 +300,8 @@ export default function adana({ types }) {
       })
     ));
     if (path.has('handler')) {
+      const handler = path.get('handler').node;
+      addRules(state, handler.loc, handler.body.leadingComments);
       path.get('handler.body').unshiftContainer(
         'body',
         types.expressionStatement(

--- a/test/fixtures/tag-error.fixture.js
+++ b/test/fixtures/tag-error.fixture.js
@@ -1,0 +1,13 @@
+let i = 0;
+
+try /* adana: +foo */ {
+  ++i;
+} catch (err) /* adana: +baz */ {
+  ++i;
+}
+
+try {
+  throw new Error();
+} catch (err) /* adana: +bar */ {
+  ++i;
+}

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -471,6 +471,13 @@ describe('Instrumenter', () => {
         expect(tags.qux[0]).to.have.property('count', 0);
       });
     });
+    it('should handle error tags', () => {
+      return run('tag-error').then(({ tags }) => {
+        expect(tags.foo[0]).to.have.property('count', 1);
+        expect(tags.bar[0]).to.have.property('count', 1);
+        expect(tags.baz[0]).to.have.property('count', 0);
+      });
+    });
     it.skip('should handle block tags', () => {
       return run('tag-block').then(({ tags }) => {
         expect(tags.statement).to.have.length(2);

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -1,3 +1,5 @@
+/* global require */
+
 import { expect } from 'chai';
 import path from 'path';
 import vm from 'vm';
@@ -11,7 +13,7 @@ import plugin, { key } from '../../dist/instrumenter';
 
 describe('Instrumenter', () => {
   const options = {
-    plugins: [ 'syntax-jsx', [ '../', {
+    plugins: [ 'syntax-jsx', [ require.resolve('../../'), {
       ignore: 'test/spec/*.spec.js',
     } ], [ 'transform-react-jsx', {
       pragma: 'createElement',


### PR DESCRIPTION
This lets you apply tags to try/catch blocks and their branches.
