### PR TITLE
Allow disabling the instrumenter entirely.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -487,6 +487,19 @@ export default function adana({ types }) {
     }
   }
 
+  function noInstrument(path) {
+    if (
+      path.node &&
+      path.node.leadingComments &&
+      path.node.leadingComments.some(
+        (comment) => /^\s*adana-no-instrument\s*$/.exec(comment.value)
+      )
+    ) {
+      path.skip();
+      return;
+    }
+  }
+
   const visitor = {
     // Expressions
     ArrowFunctionExpression: visitFunction,
@@ -513,6 +526,9 @@ export default function adana({ types }) {
     DoWhileStatement: visitWhileLoop,
     IfStatement: visitConditional,
     SwitchStatement: visitSwitchStatement,
+
+    // Generics
+    enter: noInstrument,
   };
 
   Object.keys(visitor).forEach(key => {

--- a/test/fixtures/no-instrument.fixture.js
+++ b/test/fixtures/no-instrument.fixture.js
@@ -1,0 +1,5 @@
+function zz(x) {
+  return x;
+}
+const foo = true;
+zz(/* adana-no-instrument */ foo ? 'bar.js' : 'baz.js');

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -446,6 +446,14 @@ describe('Instrumenter', () => {
     });
   });
 
+  describe('instrumentation disabling', () => {
+    it('should skip instrumenting things', () => {
+      return run('no-instrument').then(({ tags }) => {
+        expect(tags).to.not.have.property('branch');
+      });
+    });
+  });
+
   describe('tags', () => {
     it.skip('should handle line tags', () => {
       return run('tag-line').then(({ tags }) => {


### PR DESCRIPTION
Akin to the traditional `ignore` statements of other coverage tools. Intended for more exceptional cases where `adana: +ignore` will not suffice. Such is the case in `webpack` require statements with tenary branches that get evaluated at build time. For example:

``` javascript
require(true ? 'foo.js' : 'bar.js');
```

Normally `adana` will happily instrument this and break webpack's static analysis engine. For cases like this you can now use `adana-no-instrument` which will turn off the instrumenter for the ensuing AST node.

``` javascript
require( /* adana-no-instrument */ true ? 'foo.js' : 'bar.js');
```
