### PR TITLE
Replace file hash with file source.

### DIFF
--- a/share/prelude.js
+++ b/share/prelude.js
@@ -3,7 +3,7 @@
 const VARIABLE = (exports => {
   exports[GLOBAL] = exports[GLOBAL] || { };
   const coverage = exports[GLOBAL][FILE] = {
-    hash: HASH,
+    source: SOURCE,
     path: FILE,
     locations: LOCATIONS,
   };

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -1,12 +1,7 @@
-import { createHash } from 'crypto';
 import { util } from 'babel-core';
 import prelude from './prelude';
 import meta from './meta';
 import { applyRules, addRules } from './tags';
-
-export function hash(code) {
-  return createHash('sha1').update(code).digest('hex');
-}
 
 export function skip({ opts, file } = { }) {
   if (file && opts) {
@@ -544,7 +539,7 @@ export default function adana({ types }) {
           return;
         }
         meta(state, {
-          hash: hash(state.file.code),
+          source: state.file.code,
           entries: [],
           rules: [],
           tags: {},

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -16,7 +16,7 @@ export default function prelude(state) {
   const global = (state.opts && state.opts.global) || '__coverage__';
   return render({
     GLOBAL: astify(global),
-    HASH: astify(coverage.hash),
+    SOURCE: astify(coverage.source),
     TAGS: astify(coverage.tags),
     VARIABLE: coverage.variable,
     FILE: astify(name),


### PR DESCRIPTION
The `hash` value was originally there to ensure you weren't comparing coverage between files you should not have been; having the raw source also achieves this, with the upside of being able to link the coverage data to exact lines in the source. The downside is that it bloats the coverage file and could have potentially sensitive information in it.

However, since the JSON format is mostly intermediary and used by local tooling I feel this is a reasonable trade-off. This will also allow for things like uploading a JSON blob to a web tool to view coverage data without anything else.

/cc @10xjs 