### PR TITLE
Fix `return` in `try` not working correctly.

### DIFF
--- a/test/fixtures/try-catch-deferred.fixture.js
+++ b/test/fixtures/try-catch-deferred.fixture.js
@@ -1,0 +1,14 @@
+
+let i = 0;
+
+const bar = () => {};
+
+const foo = () => {
+  try {
+    return bar();
+  } catch (err) {
+    ++i;
+  }
+};
+
+foo();

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -226,6 +226,13 @@ describe('Instrumenter', () => {
           expect(tags.branch[1]).to.have.property('count', 1);
         });
     });
+    it('should cover exceptions', () => {
+      return run('try-catch-deferred').then(({ tags }) => {
+        expect(tags.branch).to.have.length(2);
+        expect(tags.branch[0]).to.have.property('count', 1);
+        expect(tags.branch[1]).to.have.property('count', 0);
+      });
+    });
   });
 
   describe('functions', () => {


### PR DESCRIPTION
The instrumenter previously located the `try` branch counter at the bottom of the try statement. Unfortunately this does not work if the `try` statement has `return` inside of it. So instead, make use of the `finally` clause.

/cc @10xjs 