### PR TITLE
Fix logic branches.

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -424,20 +424,20 @@ export default function instrumenter() {
    */
   function visitLogicalExpression(path, state) {
     const group = key(path);
-    const test = path.scope.generateDeclaredUidIdentifier('test');
-
-    path.replaceWith(X(types.conditionalExpression(
-      types.assignmentExpression('=', test, X(path.node)),
+    const left = path.get('left').node;
+    const right = path.get('right').node;
+    path.replaceWith(X(types.logicalExpression(
+      path.node.operator,
       types.sequenceExpression([createMarker(state, {
         tags: ['branch', 'logic'],
-        loc: path.get('left').node.loc,
+        loc: left.loc,
         group,
-      }), test]),
+      }), left]),
       types.sequenceExpression([createMarker(state, {
         tags: ['branch', 'logic'],
-        loc: path.get('right').node.loc,
+        loc: right.loc,
         group,
-      }), test])
+      }), right])
     )));
   }
 

--- a/test/fixtures/logic.fixture.js
+++ b/test/fixtures/logic.fixture.js
@@ -1,7 +1,3 @@
 let y = true;
-const a = !y;
-const b = y;
-const c = y;
-const d = y;
 
-y = !a || (b && c) || d;
+y = !y || (y && y) || y;

--- a/test/spec/instrumenter.spec.js
+++ b/test/spec/instrumenter.spec.js
@@ -331,15 +331,14 @@ describe('Instrumenter', () => {
   describe('logic expressions', () => {
     it('should cover logic', () => {
       return run('logic').then(({tags}) => {
-        expect(tags.branch).to.have.length(6);
-        expect(tags.branch[0]).to.have.property('count', 1);
-        expect(tags.branch[1]).to.have.property('count', 0);
-        expect(tags.branch[2]).to.have.property('count', 1);
-        expect(tags.branch[3]).to.have.property('count', 0);
-        expect(tags.branch[4]).to.have.property('count', 0);
-        expect(tags.branch[5]).to.have.property('count', 0);
-        // TODO: Fix grouping for logic statements.
-        // grouped(...tags.branch);
+        const groups = {};
+        let sum = 0;
+        tags.branch.forEach((x) => {
+          groups[x.group] = groups[x.group] ? groups[x.group].concat(x) : [x];
+          sum += x.count;
+        });
+        expect(Object.keys(groups)).to.have.length(2);
+        expect(sum).to.equal(5);
       });
     });
   });


### PR DESCRIPTION
The `else` branch does not get hit otherwise sometimes. The old code in here was overly complex, just using `(marker, x) || (marker, y)` is fine.